### PR TITLE
fix(parent#384): adapt to blocking SPIs + WorkerResult generics

### DIFF
--- a/webapp-api/src/main/java/io/casehub/iot/webapp/cbr/IoTSuppressionTriggerPolicy.java
+++ b/webapp-api/src/main/java/io/casehub/iot/webapp/cbr/IoTSuppressionTriggerPolicy.java
@@ -11,7 +11,6 @@ import io.casehub.ras.api.SuppressionMetadataKeys;
 import io.casehub.ras.api.TriggerAction;
 import io.casehub.ras.api.TriggerDecision;
 import io.casehub.ras.runtime.DefaultRasTriggerPolicy;
-import io.smallrye.mutiny.Uni;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -30,27 +29,26 @@ public class IoTSuppressionTriggerPolicy implements RasTriggerPolicy {
     }
 
     @Override
-    public Uni<PolicyDecision> evaluate(SituationContext context, SituationDefinition definition) {
-        return delegate.evaluate(context, definition).map(base -> {
-            if (base.decision() != TriggerDecision.TRIGGER
-                    && base.decision() != TriggerDecision.TRIGGER_AND_CONTINUE) {
-                return base;
-            }
-            if (isSafetyCritical(definition)) {
-                return base;
-            }
+    public PolicyDecision evaluate(SituationContext context, SituationDefinition definition) {
+        PolicyDecision base = delegate.evaluate(context, definition);
+        if (base.decision() != TriggerDecision.TRIGGER
+            && base.decision() != TriggerDecision.TRIGGER_AND_CONTINUE) {
+            return base;
+        }
+        if (isSafetyCritical(definition)) {
+            return base;
+        }
 
-            Map<String, Object> features = extractFeatures(context);
-            SuppressionAssessment assessment = suppressionEvaluator.assess(
-                    definition.situationId(), features, context.tenancyId());
+        Map<String, Object> features = extractFeatures(context);
+        SuppressionAssessment assessment = suppressionEvaluator.assess(
+                definition.situationId(), features, context.tenancyId());
 
-            return switch (assessment.tier()) {
-                case NONE -> base;
-                case ANNOTATE -> new PolicyDecision(base.decision(), buildMetadata(assessment, "annotate"));
-                case DEMOTE -> new PolicyDecision(TriggerDecision.SUPPRESS, buildMetadata(assessment, "demote"));
-                case SUPPRESS -> new PolicyDecision(TriggerDecision.SUPPRESS, buildMetadata(assessment, "full"));
-            };
-        });
+        return switch (assessment.tier()) {
+            case NONE -> base;
+            case ANNOTATE -> new PolicyDecision(base.decision(), buildMetadata(assessment, "annotate"));
+            case DEMOTE -> new PolicyDecision(TriggerDecision.SUPPRESS, buildMetadata(assessment, "demote"));
+            case SUPPRESS -> new PolicyDecision(TriggerDecision.SUPPRESS, buildMetadata(assessment, "full"));
+        };
     }
 
     private boolean isSafetyCritical(SituationDefinition definition) {

--- a/webapp-api/src/main/java/io/casehub/iot/webapp/worker/DeviceCommandWorkerFunction.java
+++ b/webapp-api/src/main/java/io/casehub/iot/webapp/worker/DeviceCommandWorkerFunction.java
@@ -11,7 +11,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.function.Function;
 
-public class DeviceCommandWorkerFunction implements Function<Map<String, Object>, WorkerResult> {
+public class DeviceCommandWorkerFunction implements Function<Map<String, Object>, WorkerResult<Map<String, Object>>> {
 
     private final Instance<DeviceProvider> providers;
     private final DeviceRegistry deviceRegistry;
@@ -22,7 +22,7 @@ public class DeviceCommandWorkerFunction implements Function<Map<String, Object>
     }
 
     @Override
-    public WorkerResult apply(Map<String, Object> input) {
+    public WorkerResult<Map<String, Object>> apply(Map<String, Object> input) {
         String targetDeviceId = (String) input.get("targetDeviceId");
         if (targetDeviceId == null) {
             return WorkerResult.failed("Missing required field: targetDeviceId");

--- a/webapp-api/src/main/java/io/casehub/iot/webapp/worker/HouseholdNotificationWorkerFunction.java
+++ b/webapp-api/src/main/java/io/casehub/iot/webapp/worker/HouseholdNotificationWorkerFunction.java
@@ -9,10 +9,10 @@ import java.util.function.Function;
  * Stub implementation for household notifications.
  * Real integration with ConnectorService will be wired in Task 4's descriptors.
  */
-public class HouseholdNotificationWorkerFunction implements Function<Map<String, Object>, WorkerResult> {
+public class HouseholdNotificationWorkerFunction implements Function<Map<String, Object>, WorkerResult<Map<String, Object>>> {
 
     @Override
-    public WorkerResult apply(Map<String, Object> input) {
+    public WorkerResult<Map<String, Object>> apply(Map<String, Object> input) {
         String tenancyId = (String) input.get("tenancyId");
         String message = (String) input.get("message");
 

--- a/webapp-api/src/main/java/io/casehub/iot/webapp/worker/HumanDecisionWorkerFunction.java
+++ b/webapp-api/src/main/java/io/casehub/iot/webapp/worker/HumanDecisionWorkerFunction.java
@@ -11,7 +11,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 
-public class HumanDecisionWorkerFunction implements Function<Map<String, Object>, WorkerResult> {
+public class HumanDecisionWorkerFunction implements Function<Map<String, Object>, WorkerResult<Map<String, Object>>> {
 
     private final WorkItemCreator workItemCreator;
 
@@ -20,7 +20,7 @@ public class HumanDecisionWorkerFunction implements Function<Map<String, Object>
     }
 
     @Override
-    public WorkerResult apply(Map<String, Object> input) {
+    public WorkerResult<Map<String, Object>> apply(Map<String, Object> input) {
         String caseId           = str(input, "caseId");
         String caseType         = str(input, "caseType");
         String planItemId       = str(input, "planItemId");

--- a/webapp-api/src/test/java/io/casehub/iot/webapp/cbr/IoTSuppressionTriggerPolicyTest.java
+++ b/webapp-api/src/test/java/io/casehub/iot/webapp/cbr/IoTSuppressionTriggerPolicyTest.java
@@ -69,7 +69,7 @@ class IoTSuppressionTriggerPolicyTest {
         var context = ctx("sit-1");
         var definition = def("sit-1", new TriggerAction.CreateCase(NORMAL_CONFIG));
 
-        var result = policy.evaluate(context, definition).await().indefinitely();
+        var result = policy.evaluate(context, definition);
 
         assertThat(result.decision()).isEqualTo(TriggerDecision.CONTINUE_ACCUMULATING);
         verifyNoInteractions(suppressionEvaluator);
@@ -80,7 +80,7 @@ class IoTSuppressionTriggerPolicyTest {
         var context = ctxWithDetection("sit-1");
         var definition = def("sit-1", new TriggerAction.CreateCase(SAFETY_CONFIG));
 
-        var result = policy.evaluate(context, definition).await().indefinitely();
+        var result = policy.evaluate(context, definition);
 
         assertThat(result.decision()).isEqualTo(TriggerDecision.TRIGGER);
         verifyNoInteractions(suppressionEvaluator);
@@ -91,7 +91,7 @@ class IoTSuppressionTriggerPolicyTest {
         var context = ctxWithDetection("smoke-detected");
         var definition = def("smoke-detected", new TriggerAction.NotifyOnly());
 
-        var result = policy.evaluate(context, definition).await().indefinitely();
+        var result = policy.evaluate(context, definition);
 
         assertThat(result.decision()).isEqualTo(TriggerDecision.TRIGGER);
         verifyNoInteractions(suppressionEvaluator);
@@ -107,7 +107,7 @@ class IoTSuppressionTriggerPolicyTest {
                 .thenReturn(new SuppressionAssessment(
                         SuppressionTier.SUPPRESS, 0.92, 15, 14, 0.85));
 
-        var result = policy.evaluate(context, definition).await().indefinitely();
+        var result = policy.evaluate(context, definition);
 
         assertThat(result.decision()).isEqualTo(TriggerDecision.SUPPRESS);
         assertThat(result.metadata())
@@ -125,7 +125,7 @@ class IoTSuppressionTriggerPolicyTest {
                 .thenReturn(new SuppressionAssessment(
                         SuppressionTier.DEMOTE, 0.78, 12, 9, 0.72));
 
-        var result = policy.evaluate(context, definition).await().indefinitely();
+        var result = policy.evaluate(context, definition);
 
         assertThat(result.decision()).isEqualTo(TriggerDecision.SUPPRESS);
         assertThat(result.metadata())
@@ -142,7 +142,7 @@ class IoTSuppressionTriggerPolicyTest {
                 .thenReturn(new SuppressionAssessment(
                         SuppressionTier.ANNOTATE, 0.45, 10, 5, 0.65));
 
-        var result = policy.evaluate(context, definition).await().indefinitely();
+        var result = policy.evaluate(context, definition);
 
         assertThat(result.decision()).isEqualTo(TriggerDecision.TRIGGER);
         assertThat(result.metadata())
@@ -160,7 +160,7 @@ class IoTSuppressionTriggerPolicyTest {
                 .thenReturn(new SuppressionAssessment(
                         SuppressionTier.NONE, 0.0, 0, 0, 0.0));
 
-        var result = policy.evaluate(context, definition).await().indefinitely();
+        var result = policy.evaluate(context, definition);
 
         assertThat(result.decision()).isEqualTo(TriggerDecision.TRIGGER);
         assertThat(result.metadata()).isEmpty();
@@ -184,7 +184,7 @@ class IoTSuppressionTriggerPolicyTest {
         when(suppressionEvaluator.assess(eq("sit-1"), any(), eq("t1")))
                 .thenReturn(new SuppressionAssessment(SuppressionTier.NONE, 0, 0, 0, 0));
 
-        policy.evaluate(context, definition).await().indefinitely();
+        policy.evaluate(context, definition);
 
         var captor = org.mockito.ArgumentCaptor.forClass(Map.class);
         org.mockito.Mockito.verify(suppressionEvaluator).assess(eq("sit-1"), captor.capture(), eq("t1"));
@@ -208,7 +208,7 @@ class IoTSuppressionTriggerPolicyTest {
         when(suppressionEvaluator.assess(eq("sit-1"), any(), eq("t1")))
                 .thenReturn(new SuppressionAssessment(SuppressionTier.NONE, 0, 0, 0, 0));
 
-        policy.evaluate(context, definition).await().indefinitely();
+        policy.evaluate(context, definition);
 
         var captor = org.mockito.ArgumentCaptor.forClass(Map.class);
         org.mockito.Mockito.verify(suppressionEvaluator).assess(eq("sit-1"), captor.capture(), eq("t1"));
@@ -233,7 +233,7 @@ class IoTSuppressionTriggerPolicyTest {
         when(suppressionEvaluator.assess(eq("sit-1"), any(), eq("t1")))
                 .thenReturn(new SuppressionAssessment(SuppressionTier.NONE, 0, 0, 0, 0));
 
-        policy.evaluate(context, definition).await().indefinitely();
+        policy.evaluate(context, definition);
 
         var captor = org.mockito.ArgumentCaptor.forClass(Map.class);
         org.mockito.Mockito.verify(suppressionEvaluator).assess(eq("sit-1"), captor.capture(), eq("t1"));

--- a/webapp-drools/src/test/java/io/casehub/iot/webapp/drools/MultiRoomMotionGanglionTest.java
+++ b/webapp-drools/src/test/java/io/casehub/iot/webapp/drools/MultiRoomMotionGanglionTest.java
@@ -63,7 +63,7 @@ class MultiRoomMotionGanglionTest {
     @Test
     void singleMotionEventReturnsNoise() {
         var event = motionEvent("motion-1", true, Instant.parse("2026-07-01T10:00:00Z"));
-        DetectionResult result = ganglion.detect(event, testContext()).await().indefinitely();
+        DetectionResult result = ganglion.detect(event, testContext());
         assertThat(result.signal()).isEqualTo(DetectionSignal.NOISE);
     }
 
@@ -72,10 +72,10 @@ class MultiRoomMotionGanglionTest {
         Instant base = Instant.parse("2026-07-01T10:00:00Z");
         var ctx = testContext();
 
-        ganglion.detect(motionEvent("motion-1", true, base), ctx).await().indefinitely();
+        ganglion.detect(motionEvent("motion-1", true, base), ctx);
         DetectionResult result = ganglion.detect(
                 motionEvent("motion-2", true, base.plusSeconds(30)), ctx)
-                .await().indefinitely();
+                ;
 
         assertThat(result.signal()).isEqualTo(DetectionSignal.NOISE);
     }
@@ -85,13 +85,13 @@ class MultiRoomMotionGanglionTest {
         Instant base = Instant.parse("2026-07-01T10:00:00Z");
         var ctx = testContext();
 
-        ganglion.detect(motionEvent("motion-1", true, base), ctx).await().indefinitely();
+        ganglion.detect(motionEvent("motion-1", true, base), ctx);
         ganglion.detect(motionEvent("motion-2", true, base.plusSeconds(30)), ctx)
-                .await().indefinitely();
+                ;
 
         DetectionResult result = ganglion.detect(
                 motionEvent("motion-3", true, base.plusSeconds(60)), ctx)
-                .await().indefinitely();
+                ;
 
         assertThat(result.signal()).isEqualTo(DetectionSignal.DETECTED);
         assertThat(result.confidence()).isGreaterThanOrEqualTo(0.7);
@@ -104,16 +104,16 @@ class MultiRoomMotionGanglionTest {
         Instant base = Instant.parse("2026-07-01T10:00:00Z");
         var ctx = testContext();
 
-        ganglion.detect(motionEvent("motion-1", true, base), ctx).await().indefinitely();
+        ganglion.detect(motionEvent("motion-1", true, base), ctx);
         ganglion.detect(motionEvent("motion-2", true, base.plusSeconds(30)), ctx)
-                .await().indefinitely();
+                ;
         // Same device (motion-1) again — doesn't add to distinct count
         ganglion.detect(motionEvent("motion-1", true, base.plusSeconds(60)), ctx)
-                .await().indefinitely();
+                ;
 
         DetectionResult result = ganglion.detect(
                 motionEvent("motion-1", true, base.plusSeconds(90)), ctx)
-                .await().indefinitely();
+                ;
 
         assertThat(result.signal()).isEqualTo(DetectionSignal.NOISE);
     }
@@ -124,15 +124,15 @@ class MultiRoomMotionGanglionTest {
         var ctx = testContext();
 
         // Only motion=true events count
-        ganglion.detect(motionEvent("motion-1", true, base), ctx).await().indefinitely();
+        ganglion.detect(motionEvent("motion-1", true, base), ctx);
         ganglion.detect(motionEvent("motion-2", false, base.plusSeconds(30)), ctx)
-                .await().indefinitely();
+                ;
         ganglion.detect(motionEvent("motion-3", true, base.plusSeconds(60)), ctx)
-                .await().indefinitely();
+                ;
 
         DetectionResult result = ganglion.detect(
                 motionEvent("motion-4", false, base.plusSeconds(90)), ctx)
-                .await().indefinitely();
+                ;
 
         // Only motion-1 and motion-3 counted (2 distinct)
         assertThat(result.signal()).isEqualTo(DetectionSignal.NOISE);
@@ -143,15 +143,15 @@ class MultiRoomMotionGanglionTest {
         Instant base = Instant.parse("2026-07-01T10:00:00Z");
         var ctx = testContext();
 
-        ganglion.detect(motionEvent("motion-1", true, base), ctx).await().indefinitely();
+        ganglion.detect(motionEvent("motion-1", true, base), ctx);
         ganglion.detect(motionEvent("motion-2", true, base.plusSeconds(20)), ctx)
-                .await().indefinitely();
+                ;
         ganglion.detect(motionEvent("motion-3", true, base.plusSeconds(40)), ctx)
-                .await().indefinitely();
+                ;
 
         DetectionResult result = ganglion.detect(
                 motionEvent("motion-4", true, base.plusSeconds(60)), ctx)
-                .await().indefinitely();
+                ;
 
         assertThat(result.signal()).isEqualTo(DetectionSignal.DETECTED);
         assertThat(result.evidence().get("distinctDevices")).isEqualTo(4);
@@ -163,14 +163,14 @@ class MultiRoomMotionGanglionTest {
         var ctx = testContext();
 
         // First two events
-        ganglion.detect(motionEvent("motion-1", true, base), ctx).await().indefinitely();
+        ganglion.detect(motionEvent("motion-1", true, base), ctx);
         ganglion.detect(motionEvent("motion-2", true, base.plusSeconds(30)), ctx)
-                .await().indefinitely();
+                ;
 
         // Third event beyond 2-minute window from first
         DetectionResult result = ganglion.detect(
                 motionEvent("motion-3", true, base.plusSeconds(121)), ctx)
-                .await().indefinitely();
+                ;
 
         // First event expired, only motion-2 and motion-3 in window (2 distinct)
         assertThat(result.signal()).isEqualTo(DetectionSignal.NOISE);
@@ -181,14 +181,14 @@ class MultiRoomMotionGanglionTest {
         var ctx = testContext();
         Instant base = Instant.parse("2026-07-01T10:00:00Z");
 
-        ganglion.detect(motionEvent("motion-1", true, base), ctx).await().indefinitely();
+        ganglion.detect(motionEvent("motion-1", true, base), ctx);
 
         // Session exists after first event
         assertThat(sessionStore.get("multi-room-motion", "intrusion", "key-1", "tenant-a"))
                 .isPresent();
 
         ganglion.detect(motionEvent("motion-2", true, base.plusSeconds(30)), ctx)
-                .await().indefinitely();
+                ;
 
         // Still present
         assertThat(sessionStore.get("multi-room-motion", "intrusion", "key-1", "tenant-a"))
@@ -199,12 +199,12 @@ class MultiRoomMotionGanglionTest {
     void closeRemovesSession() {
         var ctx = testContext();
         ganglion.detect(motionEvent("motion-1", true, Instant.parse("2026-07-01T10:00:00Z")), ctx)
-                .await().indefinitely();
+                ;
 
         assertThat(sessionStore.get("multi-room-motion", "intrusion", "key-1", "tenant-a"))
                 .isPresent();
 
-        ganglion.close("intrusion", "key-1", "tenant-a").await().indefinitely();
+        ganglion.close("intrusion", "key-1", "tenant-a");
 
         assertThat(sessionStore.get("multi-room-motion", "intrusion", "key-1", "tenant-a"))
                 .isEmpty();

--- a/webapp-drools/src/test/java/io/casehub/iot/webapp/drools/SustainedTemperatureRiseGanglionTest.java
+++ b/webapp-drools/src/test/java/io/casehub/iot/webapp/drools/SustainedTemperatureRiseGanglionTest.java
@@ -91,7 +91,7 @@ class SustainedTemperatureRiseGanglionTest {
     void singleReadingReturnsNoise() {
         var event = sensorEvent("temp-1", new BigDecimal("20.0"),
                 Instant.parse("2026-07-01T10:00:00Z"));
-        DetectionResult result = ganglion.detect(event, testContext()).await().indefinitely();
+        DetectionResult result = ganglion.detect(event, testContext());
         assertThat(result.signal()).isEqualTo(DetectionSignal.NOISE);
     }
 
@@ -102,18 +102,18 @@ class SustainedTemperatureRiseGanglionTest {
 
         // Rising: 20, 22.5, 25, 27.5, 30 (delta >= 2C each)
         ganglion.detect(sensorEvent("temp-1", new BigDecimal("20.0"), base), ctx)
-                .await().indefinitely();
+                ;
         ganglion.detect(sensorEvent("temp-1", new BigDecimal("22.5"), base.plusSeconds(60)), ctx)
-                .await().indefinitely();
+                ;
         ganglion.detect(sensorEvent("temp-1", new BigDecimal("25.0"), base.plusSeconds(120)), ctx)
-                .await().indefinitely();
+                ;
         ganglion.detect(sensorEvent("temp-1", new BigDecimal("27.5"), base.plusSeconds(180)), ctx)
-                .await().indefinitely();
+                ;
 
         // Fifth reading triggers detection
         DetectionResult result = ganglion.detect(
                 sensorEvent("temp-1", new BigDecimal("30.0"), base.plusSeconds(240)), ctx)
-                .await().indefinitely();
+                ;
 
         assertThat(result.signal()).isEqualTo(DetectionSignal.DETECTED);
         assertThat(result.confidence()).isGreaterThanOrEqualTo(0.8);
@@ -127,17 +127,17 @@ class SustainedTemperatureRiseGanglionTest {
 
         // Not monotonic: 20, 22, 21, 23, 25 — third reading drops
         ganglion.detect(sensorEvent("temp-1", new BigDecimal("20.0"), base), ctx)
-                .await().indefinitely();
+                ;
         ganglion.detect(sensorEvent("temp-1", new BigDecimal("22.0"), base.plusSeconds(60)), ctx)
-                .await().indefinitely();
+                ;
         ganglion.detect(sensorEvent("temp-1", new BigDecimal("21.0"), base.plusSeconds(120)), ctx)
-                .await().indefinitely();
+                ;
         ganglion.detect(sensorEvent("temp-1", new BigDecimal("23.0"), base.plusSeconds(180)), ctx)
-                .await().indefinitely();
+                ;
 
         DetectionResult result = ganglion.detect(
                 sensorEvent("temp-1", new BigDecimal("25.0"), base.plusSeconds(240)), ctx)
-                .await().indefinitely();
+                ;
 
         assertThat(result.signal()).isEqualTo(DetectionSignal.NOISE);
     }
@@ -149,17 +149,17 @@ class SustainedTemperatureRiseGanglionTest {
 
         // Rising but deltas < 2C: 20, 21.5, 23, 24.5, 26
         ganglion.detect(sensorEvent("temp-1", new BigDecimal("20.0"), base), ctx)
-                .await().indefinitely();
+                ;
         ganglion.detect(sensorEvent("temp-1", new BigDecimal("21.5"), base.plusSeconds(60)), ctx)
-                .await().indefinitely();
+                ;
         ganglion.detect(sensorEvent("temp-1", new BigDecimal("23.0"), base.plusSeconds(120)), ctx)
-                .await().indefinitely();
+                ;
         ganglion.detect(sensorEvent("temp-1", new BigDecimal("24.5"), base.plusSeconds(180)), ctx)
-                .await().indefinitely();
+                ;
 
         DetectionResult result = ganglion.detect(
                 sensorEvent("temp-1", new BigDecimal("26.0"), base.plusSeconds(240)), ctx)
-                .await().indefinitely();
+                ;
 
         assertThat(result.signal()).isEqualTo(DetectionSignal.NOISE);
     }
@@ -171,17 +171,17 @@ class SustainedTemperatureRiseGanglionTest {
 
         // Mix sensor and thermostat events
         ganglion.detect(thermostatEvent("therm-1", new BigDecimal("20.0"), base), ctx)
-                .await().indefinitely();
+                ;
         ganglion.detect(sensorEvent("temp-1", new BigDecimal("22.5"), base.plusSeconds(60)), ctx)
-                .await().indefinitely();
+                ;
         ganglion.detect(thermostatEvent("therm-1", new BigDecimal("25.0"), base.plusSeconds(120)), ctx)
-                .await().indefinitely();
+                ;
         ganglion.detect(sensorEvent("temp-1", new BigDecimal("27.5"), base.plusSeconds(180)), ctx)
-                .await().indefinitely();
+                ;
 
         DetectionResult result = ganglion.detect(
                 thermostatEvent("therm-1", new BigDecimal("30.0"), base.plusSeconds(240)), ctx)
-                .await().indefinitely();
+                ;
 
         assertThat(result.signal()).isEqualTo(DetectionSignal.DETECTED);
     }
@@ -192,22 +192,22 @@ class SustainedTemperatureRiseGanglionTest {
         Instant base = Instant.parse("2026-07-01T10:00:00Z");
 
         ganglion.detect(sensorEvent("temp-1", new BigDecimal("20.0"), base), ctx)
-                .await().indefinitely();
+                ;
         ganglion.detect(sensorEvent("temp-1", new BigDecimal("22.5"), base.plusSeconds(60)), ctx)
-                .await().indefinitely();
+                ;
 
         // Session should exist in store
         assertThat(sessionStore.get("sustained-rise", "fire-risk", "key-1", "tenant-a"))
                 .isPresent();
 
         ganglion.detect(sensorEvent("temp-1", new BigDecimal("25.0"), base.plusSeconds(120)), ctx)
-                .await().indefinitely();
+                ;
         ganglion.detect(sensorEvent("temp-1", new BigDecimal("27.5"), base.plusSeconds(180)), ctx)
-                .await().indefinitely();
+                ;
 
         DetectionResult result = ganglion.detect(
                 sensorEvent("temp-1", new BigDecimal("30.0"), base.plusSeconds(240)), ctx)
-                .await().indefinitely();
+                ;
 
         assertThat(result.signal()).isEqualTo(DetectionSignal.DETECTED);
     }
@@ -216,12 +216,12 @@ class SustainedTemperatureRiseGanglionTest {
     void closeRemovesSession() {
         var ctx = testContext();
         ganglion.detect(sensorEvent("temp-1", new BigDecimal("20.0"),
-                Instant.parse("2026-07-01T10:00:00Z")), ctx).await().indefinitely();
+                Instant.parse("2026-07-01T10:00:00Z")), ctx);
 
         assertThat(sessionStore.get("sustained-rise", "fire-risk", "key-1", "tenant-a"))
                 .isPresent();
 
-        ganglion.close("fire-risk", "key-1", "tenant-a").await().indefinitely();
+        ganglion.close("fire-risk", "key-1", "tenant-a");
 
         assertThat(sessionStore.get("sustained-rise", "fire-risk", "key-1", "tenant-a"))
                 .isEmpty();
@@ -232,13 +232,13 @@ class SustainedTemperatureRiseGanglionTest {
         var ctx = testContext();
 
         ganglion.detect(sensorEvent("temp-1", new BigDecimal("20.0"),
-                Instant.parse("2026-07-01T10:01:00Z")), ctx).await().indefinitely();
+                Instant.parse("2026-07-01T10:01:00Z")), ctx);
 
         var outOfOrderEvent = sensorEvent("temp-1", new BigDecimal("22.0"),
                 Instant.parse("2026-07-01T10:00:00Z"));
 
         org.junit.jupiter.api.Assertions.assertThrows(
                 IllegalStateException.class,
-                () -> ganglion.detect(outOfOrderEvent, ctx).await().indefinitely());
+                () -> ganglion.detect(outOfOrderEvent, ctx));
     }
 }

--- a/webapp/src/main/java/io/casehub/iot/webapp/app/rest/SituationResource.java
+++ b/webapp/src/main/java/io/casehub/iot/webapp/app/rest/SituationResource.java
@@ -355,14 +355,13 @@ public class SituationResource {
         String tenancyId = principal.tenancyId();
 
         var context = situationStore.find(request.situationId(), correlationKey, tenancyId)
-                                    .await().indefinitely().orElse(null);
+                                    .orElse(null);
 
         dismissalRecorder.recordDismissal(
                 request.situationId(), correlationKey, tenancyId, context, request.reason());
 
         if (context != null) {
-            situationStore.remove(request.situationId(), correlationKey, tenancyId)
-                          .await().indefinitely();
+            situationStore.remove(request.situationId(), correlationKey, tenancyId);
             changeEvent.fireAsync(new io.casehub.ras.api.SituationChangeEvent(
                     tenancyId, request.situationId(), correlationKey,
                     io.casehub.ras.api.SituationChangeEvent.ChangeType.DISMISSED, context));


### PR DESCRIPTION
Replaces #70 (stale head ref).

- Adapt to blocking RAS SPIs (parent#384)
- WorkerResult<R> generics (engine API change)
- FeatureVectorCbrCase new fields trustScore + producerAgentId (neocortex)

Note: may fail on missing casehub-platform-view BOM entry — separate platform publishing issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)