### PR TITLE
fix(ci): adapt to upstream API changes

### DIFF
--- a/webapp/src/main/java/io/casehub/iot/webapp/app/cbr/WorkItemOutcomeRecorder.java
+++ b/webapp/src/main/java/io/casehub/iot/webapp/app/cbr/WorkItemOutcomeRecorder.java
@@ -13,7 +13,7 @@ import io.casehub.platform.api.path.Path;
 import io.casehub.work.api.WorkItemStatus;
 import io.casehub.work.api.WorkItemStatusEvent;
 import io.casehub.work.api.spi.WorkItemObserver;
-import io.casehub.work.runtime.model.WorkItemEntity;
+import io.casehub.work.api.WorkItem;
 import io.casehub.work.runtime.service.WorkItemService;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -39,7 +39,7 @@ public class WorkItemOutcomeRecorder implements WorkItemObserver {
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
     private final CbrCaseMemoryStore                       store;
-    private final Function<UUID, Optional<WorkItemEntity>> workItemLookup;
+    private final Function<UUID, Optional<WorkItem>> workItemLookup;
     private final CaseInstanceCache                        caseInstanceCache;
     private final WorkItemCbrConfig config;
 
@@ -52,7 +52,7 @@ public class WorkItemOutcomeRecorder implements WorkItemObserver {
     }
 
     WorkItemOutcomeRecorder(CbrCaseMemoryStore store,
-                             Function<UUID, Optional<WorkItemEntity>> workItemLookup,
+                             Function<UUID, Optional<WorkItem>> workItemLookup,
                              CaseInstanceCache caseInstanceCache,
                              WorkItemCbrConfig config) {
         this.store = store;
@@ -75,18 +75,18 @@ public class WorkItemOutcomeRecorder implements WorkItemObserver {
             var workItem = workItemOpt.get();
             var ctx = buildContext(workItem, event);
             var rawFeatures = WorkItemFeatureExtractor.extractForRetain(ctx);
-            String solution = coalesce(workItem.resolution, event.outcome(),
+            String solution = coalesce(workItem.resolution(), event.outcome(),
                     event.detail(), event.status().name());
 
             var cbrCase = new FeatureVectorCbrCase(
-                    workItem.title != null ? workItem.title : "work-item",
+                    workItem.title() != null ? workItem.title() : "work-item",
                     solution,
                     event.status().name(),
                     1.0,
                     FeatureValue.toFeatureMap(rawFeatures),
                     null, null);
 
-            String caseId = parseCaseId(workItem.payload);
+            String caseId = parseCaseId(workItem.payload());
             store.store(cbrCase, "iot-work-item", event.workItemId().toString(),
                     new MemoryDomain("iot"), event.tenancyId(),
                     caseId, Path.root());
@@ -95,8 +95,8 @@ public class WorkItemOutcomeRecorder implements WorkItemObserver {
         }
     }
 
-    private WorkItemContext buildContext(WorkItemEntity workItem, WorkItemStatusEvent event) {
-        var payload = parsePayload(workItem.payload);
+    private WorkItemContext buildContext(WorkItem workItem, WorkItemStatusEvent event) {
+        var payload = parsePayload(workItem.payload());
         String deviceClass = (String) payload.get("deviceClass");
         String roomType = (String) payload.get("roomType");
         String caseType = (String) payload.get("caseType");
@@ -121,19 +121,19 @@ public class WorkItemOutcomeRecorder implements WorkItemObserver {
         }
 
         return new WorkItemContext(
-                workItem.title, workItem.description,
-                workItem.types != null
-                        ? workItem.types.stream().map(t -> t.path).toList()
+                workItem.title(), workItem.description(),
+                workItem.types() != null
+                        ? List.copyOf(workItem.types())
                         : List.of(),
-                workItem.priority != null ? workItem.priority.name() : "MEDIUM",
-                workItem.candidateGroups,
+                workItem.priority() != null ? workItem.priority().name() : "MEDIUM",
+                workItem.candidateGroups(),
                 workerName != null ? workerName : "unknown",
                 caseType != null ? caseType : "unknown",
                 deviceClass, roomType,
                 eventTs != null ? Instant.parse(eventTs) : null,
                 event.status().name(),
-                workItem.assigneeId,
-                workItem.createdAt,
+                workItem.assigneeId(),
+                workItem.createdAt(),
                 Instant.now());
     }
 

--- a/webapp/src/main/java/io/casehub/iot/webapp/app/resolution/IoTAiResolutionAgent.java
+++ b/webapp/src/main/java/io/casehub/iot/webapp/app/resolution/IoTAiResolutionAgent.java
@@ -337,7 +337,8 @@ public class IoTAiResolutionAgent {
                     MULTI_TURN_SYSTEM_PROMPT,
                     List.of(),
                     java.time.Duration.ofSeconds(config.timeoutSeconds()),
-                    "iot-resolution-" + entry.getCaseId()));
+                    "iot-resolution-" + entry.getCaseId(),
+                    null));
 
             io.micrometer.core.instrument.Timer.Sample convSample = io.micrometer.core.instrument.Timer.start(registry);
             var collector = new AgentEventCollector(objectMapper);

--- a/webapp/src/main/java/io/casehub/iot/webapp/app/rest/WorkItemResource.java
+++ b/webapp/src/main/java/io/casehub/iot/webapp/app/rest/WorkItemResource.java
@@ -176,12 +176,12 @@ public class WorkItemResource {
         }
 
         return new WorkItemContext(
-                workItem.title, workItem.description,
-                workItem.types != null
-                ? workItem.types.stream().map(t -> t.path).toList()
+                workItem.title(), workItem.description(),
+                workItem.types() != null
+                ? java.util.List.copyOf(workItem.types())
                 : java.util.List.of(),
-                workItem.priority != null ? workItem.priority.name() : "MEDIUM",
-                workItem.candidateGroups,
+                workItem.priority() != null ? workItem.priority().name() : "MEDIUM",
+                workItem.candidateGroups(),
                 workerName != null ? workerName : "unknown",
                 caseType != null ? caseType : "unknown",
                 deviceClass, roomType,

--- a/webapp/src/test/java/io/casehub/iot/webapp/app/cbr/WorkItemOutcomeRecorderTest.java
+++ b/webapp/src/test/java/io/casehub/iot/webapp/app/cbr/WorkItemOutcomeRecorderTest.java
@@ -7,7 +7,6 @@ import io.casehub.neocortex.memory.MemoryDomain;
 import io.casehub.neocortex.memory.cbr.*;
 import io.casehub.platform.api.path.Path;
 import io.casehub.work.api.*;
-import io.casehub.work.runtime.model.WorkItemEntity;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
@@ -28,7 +27,7 @@ class WorkItemOutcomeRecorderTest {
                 """);
         var recorder = recorder(store, workItem, enabledConfig());
 
-        recorder.onStatusChange(terminalEvent(workItem.id, WorkItemStatus.COMPLETED, "tech-1"));
+        recorder.onStatusChange(terminalEvent(workItem.id(), WorkItemStatus.COMPLETED, "tech-1"));
 
         assertThat(captured).hasSize(1);
         assertThat(captured.getFirst().outcome()).isEqualTo("COMPLETED");
@@ -53,7 +52,7 @@ class WorkItemOutcomeRecorderTest {
         var workItem = testWorkItem(WorkItemStatus.COMPLETED, "tech-1", "{}");
         var recorder = recorder(captureStore(captured), workItem, disabledConfig());
 
-        recorder.onStatusChange(terminalEvent(workItem.id, WorkItemStatus.COMPLETED, "tech-1"));
+        recorder.onStatusChange(terminalEvent(workItem.id(), WorkItemStatus.COMPLETED, "tech-1"));
 
         assertThat(captured).isEmpty();
     }
@@ -68,7 +67,7 @@ class WorkItemOutcomeRecorderTest {
                 """);
         var recorder = recorder(captureStore(captured), workItem, enabledConfig());
 
-        recorder.onStatusChange(terminalEvent(workItem.id, WorkItemStatus.COMPLETED, "tech-1"));
+        recorder.onStatusChange(terminalEvent(workItem.id(), WorkItemStatus.COMPLETED, "tech-1"));
 
         assertThat(captured).hasSize(1);
         var features = captured.getFirst().features();
@@ -82,7 +81,7 @@ class WorkItemOutcomeRecorderTest {
         var workItem = testWorkItem(WorkItemStatus.COMPLETED, "tech-1", null);
         var recorder = recorder(captureStore(captured), workItem, enabledConfig());
 
-        recorder.onStatusChange(terminalEvent(workItem.id, WorkItemStatus.COMPLETED, "tech-1"));
+        recorder.onStatusChange(terminalEvent(workItem.id(), WorkItemStatus.COMPLETED, "tech-1"));
 
         assertThat(captured).hasSize(1);
         var features = captured.getFirst().features();
@@ -93,12 +92,11 @@ class WorkItemOutcomeRecorderTest {
     @Test
     void solutionFallback_usesStatusNameWhenNoResolution() {
         var captured = new ArrayList<CbrCase>();
-        var workItem = testWorkItem(WorkItemStatus.CANCELLED, null, "{}");
-        workItem.resolution = null;
+        var workItem = testWorkItem(WorkItemStatus.CANCELLED, null, "{}", null);
         var recorder = recorder(captureStore(captured), workItem, enabledConfig());
 
         recorder.onStatusChange(new WorkItemStatusEvent(
-                WorkEventType.CANCELLED, workItem.id, WorkItemStatus.CANCELLED,
+                WorkEventType.CANCELLED, workItem.id(), WorkItemStatus.CANCELLED,
                 "system", null, null, null, null, null, "t1", Instant.now()));
 
         assertThat(captured).hasSize(1);
@@ -108,28 +106,32 @@ class WorkItemOutcomeRecorderTest {
     // --- helpers ---
 
     private static WorkItemOutcomeRecorder recorder(CbrCaseMemoryStore store,
-                                                     WorkItemEntity workItem,
+                                                     WorkItem workItem,
                                                      WorkItemCbrConfig config) {
         return new WorkItemOutcomeRecorder(store, id ->
-                workItem != null && workItem.id.equals(id)
+                workItem != null && workItem.id().equals(id)
                         ? Optional.of(workItem) : Optional.empty(),
                 emptyCache(), config);
     }
 
-    private static WorkItemEntity testWorkItem(WorkItemStatus status, String assignee, String payload) {
-        var wi = new WorkItemEntity();
-        wi.id = UUID.randomUUID();
-        wi.status = status;
-        wi.title = "Test work item";
-        wi.description = "Test description";
-        wi.priority = WorkItemPriority.HIGH;
-        wi.candidateGroups = "hvac-technicians";
-        wi.assigneeId = assignee;
-        wi.payload = payload;
-        wi.resolution = assignee != null ? "Resolved by " + assignee : null;
-        wi.createdAt = Instant.parse("2026-07-17T12:00:00Z");
-        wi.tenancyId = "t1";
-        return wi;
+    private static WorkItem testWorkItem(WorkItemStatus status, String assignee, String payload) {
+        return testWorkItem(status, assignee, payload, assignee != null ? "Resolved by " + assignee : null);
+    }
+
+    private static WorkItem testWorkItem(WorkItemStatus status, String assignee, String payload, String resolution) {
+        return WorkItem.builder()
+                .id(UUID.randomUUID())
+                .tenancyId("t1")
+                .title("Test work item")
+                .description("Test description")
+                .status(status)
+                .priority(WorkItemPriority.HIGH)
+                .candidateGroups("hvac-technicians")
+                .assigneeId(assignee)
+                .payload(payload)
+                .resolution(resolution)
+                .createdAt(Instant.parse("2026-07-17T12:00:00Z"))
+                .build();
     }
 
     private static WorkItemStatusEvent terminalEvent(UUID workItemId, WorkItemStatus status,


### PR DESCRIPTION
## Summary
- **WorkItem** became a record in `casehub-work-api` — field access → accessor methods, `types` changed from `List<TypeWithPath>` to `Set<String>`
- **AgentSessionInit** added a 5th `model` parameter — pass `null` for default backend
- **WorkItemOutcomeRecorder** updated from `WorkItemEntity` to `WorkItem` API type to match `WorkItemService.findById()` return type change

## Test plan
- [x] `mvn install` passes locally (all modules)
- [ ] CI green after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)