### PR TITLE
fix(#96): resolve quarkus:dev split-package duplicate bean failure

### DIFF
--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -260,6 +260,9 @@
                         <goals><goal>build</goal></goals>
                     </execution>
                 </executions>
+                <configuration>
+                    <workspaceDiscovery>false</workspaceDiscovery>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/webapp/src/main/resources/application.properties
+++ b/webapp/src/main/resources/application.properties
@@ -48,6 +48,13 @@ casehub.iot.openhab.enabled=false
 casehub.iot.webapp.state-history.retention-days=30
 casehub.iot.webapp.state-history.purge-interval=PT1H
 
+# ─── Connector stubs (dev mode only — no real Twilio/WhatsApp in local dev) ──
+%dev.casehub.connectors.twilio.account-sid=dev-sid
+%dev.casehub.connectors.twilio.auth-token=dev-token
+%dev.casehub.connectors.twilio.from=+10000000000
+%dev.casehub.connectors.whatsapp.phone-number-id=dev-phone
+%dev.casehub.connectors.whatsapp.api-token=dev-token
+
 # ─── Tenancy ─────────────────────────────────────────────────────────────────
 casehub.iot.tenancy-id=default-tenant
 


### PR DESCRIPTION
## Summary

- Disable `workspaceDiscovery` in `quarkus-maven-plugin` — prevents dev mode from treating sibling modules as both JAR dependencies and hot-reload sources, which caused `@ConfigMapping` beans (`JpaAuditRetentionConfig`, `HomeAssistantConfig`, `OpenHabConfig`) to be registered twice
- Add `%dev.` connector stubs for Twilio/WhatsApp — required by platform config validation but irrelevant for local development

## Test plan

- [ ] `mvn quarkus:dev -pl webapp` starts without `IllegalStateException: A synthetic bean ... is already registered`
- [ ] OpenHAB provider connects when enabled via `-Dcasehub.iot.openhab.enabled=true`
- [ ] CI build unaffected (workspace discovery only applies to dev mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)